### PR TITLE
Fixed trailing slash in run_local_server

### DIFF
--- a/google_auth_oauthlib/flow.py
+++ b/google_auth_oauthlib/flow.py
@@ -453,7 +453,7 @@ class InstalledAppFlow(Flow):
             host, port, wsgi_app, handler_class=_WSGIRequestHandler
         )
 
-        self.redirect_uri = "http://{}:{}/".format(host, local_server.server_port)
+        self.redirect_uri = "http://{}:{}".format(host, local_server.server_port)
         auth_url, _ = self.authorization_url(**kwargs)
 
         if open_browser:


### PR DESCRIPTION
Should fix the [ Issue #80 ](https://github.com/googleapis/google-auth-library-python-oauthlib/issues/80#issue-636623645)